### PR TITLE
Move focused comment field above the on-screen keyboard

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { FastCommentsCommentWidget } from '../../src/index';
-import { View, StyleSheet } from 'react-native';
+import { ScrollView, StyleSheet } from 'react-native';
 import { useTheme } from './ShowcaseApp';
 
 export default function App() {
@@ -43,13 +43,17 @@ export default function App() {
   const widgetKey = `${urlId}::${ssoConfig.timestamp}::${isDark ? 'd' : 'l'}`;
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+    >
       <FastCommentsCommentWidget
         key={widgetKey}
         config={widgetConfig()}
         backgroundColor="transparent"
       />
-    </View>
+    </ScrollView>
   );
 }
 
@@ -57,5 +61,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
+  },
+  content: {
+    flexGrow: 1,
   },
 });

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -4,12 +4,17 @@ import { FastCommentsCommentWidget } from '../../src/index';
 import { ScrollView, StyleSheet } from 'react-native';
 import { useTheme } from './ShowcaseApp';
 
+const DARK_BG = '#0b0b0b';
+const LIGHT_BG = '#ffffff';
+
 export default function App() {
   const { isDark } = useTheme();
   const FAST_COMMENTS_TENANT_ID = 'demo';
   const urlId = 'native-test';
   const url = 'https://example.com/external-page';
-  const now = Date.now();
+  // Keep the timestamp stable across renders so the widget key only changes on
+  // theme toggle, not on every render.
+  const timestampRef = React.useRef(Date.now());
 
   // Simulate postData from customer's app
   const postData = {
@@ -17,7 +22,7 @@ export default function App() {
   };
 
   const ssoConfig = {
-    timestamp: now,
+    timestamp: timestampRef.current,
   };
 
   const widgetConfig = () => {
@@ -44,14 +49,14 @@ export default function App() {
 
   return (
     <ScrollView
-      style={styles.container}
+      style={[styles.container, { backgroundColor: isDark ? DARK_BG : LIGHT_BG }]}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
     >
       <FastCommentsCommentWidget
         key={widgetKey}
         config={widgetConfig()}
-        backgroundColor="transparent"
+        backgroundColor={isDark ? DARK_BG : 'transparent'}
       />
     </ScrollView>
   );
@@ -60,7 +65,6 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
   },
   content: {
     flexGrow: 1,

--- a/example/src/CallbacksExampleApp.tsx
+++ b/example/src/CallbacksExampleApp.tsx
@@ -78,8 +78,8 @@ export default function CallbacksExampleApp() {
 
   return (
     <ScrollView style={styles.container}>
-      {callbacksCalled.map((value) => (
-        <Text>{value}</Text>
+      {callbacksCalled.map((value, i) => (
+        <Text key={i}>{value}</Text>
       ))}
       <FastCommentsCommentWidget config={config} />
     </ScrollView>

--- a/example/src/ShowcaseApp.tsx
+++ b/example/src/ShowcaseApp.tsx
@@ -27,7 +27,7 @@ type ExampleMeta = {
 
 const EXAMPLES: ExampleMeta[] = [
   { key: 'basic', label: 'Live Comment Widget', kind: 'widget', blurb: 'The flagship live commenting widget. Replies, voting, moderation.', Component: App },
-  { key: 'callbacks', label: 'Event Callbacks', kind: 'flow', blurb: 'Every lifecycle and action event mirrored in a live log.', Component: CallbacksExampleApp },
+  { key: 'callbacks', label: 'Event Callbacks', kind: 'config demo', blurb: 'Every lifecycle and action event mirrored in a live log.', Component: CallbacksExampleApp },
 ];
 
 let userOverride: Theme | null = null;
@@ -101,6 +101,7 @@ export default function ShowcaseApp() {
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
+          style={styles.tabBar}
           contentContainerStyle={styles.tabRow}
         >
           {EXAMPLES.map((e) => {
@@ -219,10 +220,15 @@ const styles = StyleSheet.create({
   themeBtnTextActive: {
     color: '#ffffff',
   },
+  tabBar: {
+    flexGrow: 0,
+    flexShrink: 0,
+  },
   tabRow: {
     paddingHorizontal: 16,
     paddingVertical: 14,
     gap: 10,
+    alignItems: 'flex-start',
   },
   tab: {
     paddingHorizontal: 14,

--- a/src/__tests__/keyboard-avoidance.test.ts
+++ b/src/__tests__/keyboard-avoidance.test.ts
@@ -1,0 +1,65 @@
+import { computeKeyboardAvoidHeight } from '../keyboard-avoidance';
+
+describe('computeKeyboardAvoidHeight', () => {
+  it('returns the full auto height when the widget already fits above the keyboard', () => {
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 300,
+        containerTopY: 0,
+        keyboardTopY: 600,
+      })
+    ).toBe(300);
+  });
+
+  it('does not cap when the available space exactly equals the content height', () => {
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 400,
+        containerTopY: 100,
+        keyboardTopY: 500,
+      })
+    ).toBe(400);
+  });
+
+  it('caps tall content to the space between the widget top and the keyboard', () => {
+    // 2000px of content, widget starts at y=100, keyboard top at y=500 => 400px visible
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 2000,
+        containerTopY: 100,
+        keyboardTopY: 500,
+      })
+    ).toBe(400);
+  });
+
+  it('uses the visible band height when the widget is scrolled partly off the top of the screen', () => {
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 2000,
+        containerTopY: -300,
+        keyboardTopY: 500,
+      })
+    ).toBe(800);
+  });
+
+  it('clamps to a minimum height when the widget is almost entirely behind the keyboard', () => {
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 2000,
+        containerTopY: 480,
+        keyboardTopY: 500,
+      })
+    ).toBe(120);
+  });
+
+  it('honors a custom minimum height', () => {
+    expect(
+      computeKeyboardAvoidHeight({
+        autoHeight: 2000,
+        containerTopY: 480,
+        keyboardTopY: 500,
+        minHeight: 60,
+      })
+    ).toBe(60);
+  });
+});

--- a/src/embed-core.tsx
+++ b/src/embed-core.tsx
@@ -4,13 +4,17 @@ import type {
   FastCommentsSSO,
   FastCommentsCommentWidgetConfig,
 } from 'fastcomments-typescript';
-import { ActivityIndicator, ColorValue, Linking } from 'react-native';
+import { ActivityIndicator, ColorValue, Keyboard, Linking, View } from 'react-native';
 import {
   WebViewErrorEvent,
   WebViewMessageEvent,
   WebViewNavigationEvent,
   WebViewNavigation,
 } from 'react-native-webview/lib/WebViewTypes';
+import {
+  buildKeyboardAvoidanceScript,
+  computeKeyboardAvoidHeight,
+} from './keyboard-avoidance';
 
 export interface FastCommentsWidgetParameters {
   config: FastCommentsCommentWidgetConfig;
@@ -25,6 +29,15 @@ export interface FastCommentsWidgetParameters {
     errorCode: number,
     errorDesc: string
   ) => ReactElement;
+  /**
+   * The comment UI is rendered inside a WebView whose height tracks its
+   * content, so by default a focused comment field can end up hidden behind the
+   * on-screen keyboard. When the keyboard opens we temporarily shrink the
+   * WebView to the space above it and scroll the focused field into view. Set
+   * this to `true` to disable that behavior (e.g. if you handle keyboard
+   * avoidance yourself in the host layout).
+   */
+  disableKeyboardAvoidance?: boolean;
 }
 
 export function FastCommentsEmbedCore(
@@ -32,13 +45,21 @@ export function FastCommentsEmbedCore(
   widgetId: string
 ) {
   const [uri, setURI] = useState('');
-  const [height, setHeight] = useState(500);
+  // The full content height the embedded page reports. While the keyboard is
+  // open we render `cappedHeight` instead, so the focused field has room to
+  // scroll above the keyboard (see keyboard-avoidance.ts).
+  const [autoHeight, setAutoHeight] = useState(500);
+  const [cappedHeight, setCappedHeight] = useState<number | null>(null);
   const instanceIdRef = useRef<string>(
     props.config.instanceId ?? Math.random() + '.' + Date.now()
   );
 
-  let lastHeight = 0;
-  let webview: WebView | null;
+  const webviewRef = useRef<WebView | null>(null);
+  const containerRef = useRef<View | null>(null);
+  const lastHeightRef = useRef(0);
+  const autoHeightRef = useRef(500);
+  const inputFocusedRef = useRef(false);
+  const keyboardTopYRef = useRef<number | null>(null);
   const callbackKeys = [
     'commentCountUpdated',
     'onReplySuccess',
@@ -82,15 +103,61 @@ export function FastCommentsEmbedCore(
   function updateHeight(value: number) {
     if (
       // Always handle the widget growing.
-      value > lastHeight ||
+      value > lastHeightRef.current ||
       // Only handle the widget shrinking, if it's by more than 50px.
-      Math.abs(value - lastHeight) > 100 ||
+      Math.abs(value - lastHeightRef.current) > 100 ||
       // Handle the widget hiding itself.
       value === 0
     ) {
-      lastHeight = value;
-      setHeight(value);
+      lastHeightRef.current = value;
+      autoHeightRef.current = value;
+      setAutoHeight(value);
     }
+  }
+
+  // Ask the embedded page to scroll the focused field into view, after the
+  // WebView has resized. Fires twice to cover the keyboard animation settling.
+  function scheduleScrollIntoView() {
+    const inject = () => {
+      webviewRef.current?.injectJavaScript(
+        'window.__fcScrollFocusedIntoView && window.__fcScrollFocusedIntoView(); true;'
+      );
+    };
+    setTimeout(inject, 50);
+    setTimeout(inject, 300);
+  }
+
+  // When a field is focused and the keyboard is up, shrink the WebView so its
+  // bottom edge sits at the top of the keyboard, then pull the field into view.
+  function applyKeyboardAvoidance() {
+    if (props.disableKeyboardAvoidance) {
+      return;
+    }
+    if (!inputFocusedRef.current || keyboardTopYRef.current === null) {
+      return;
+    }
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+    node.measureInWindow((_x, y) => {
+      const keyboardTopY = keyboardTopYRef.current;
+      if (keyboardTopY === null) {
+        return;
+      }
+      const effective = computeKeyboardAvoidHeight({
+        autoHeight: autoHeightRef.current,
+        containerTopY: y,
+        keyboardTopY,
+      });
+      setCappedHeight(effective < autoHeightRef.current ? effective : null);
+      scheduleScrollIntoView();
+    });
+  }
+
+  function clearKeyboardAvoidance() {
+    keyboardTopYRef.current = null;
+    setCappedHeight(null);
   }
 
   function shouldStartLoadWithRequest(request: WebViewNavigation): boolean {
@@ -166,9 +233,14 @@ export function FastCommentsEmbedCore(
       } else if (data.type === 'on-comments-rendered') {
         configFunctions.onCommentsRendered &&
           configFunctions.onCommentsRendered(data.comments);
+      } else if (data.type === 'fc-input-focus') {
+        inputFocusedRef.current = true;
+        applyKeyboardAvoidance();
+      } else if (data.type === 'fc-input-blur') {
+        inputFocusedRef.current = false;
       } else if (data.type === 'open-profile') {
         if (configFunctions.onOpenProfile) {
-          if (configFunctions.onOpenProfile(data.userId) && webview) {
+          if (configFunctions.onOpenProfile(data.userId) && webviewRef.current) {
             const js = `
                       (function () {
                           window.dispatchEvent(new MessageEvent('message', {
@@ -179,7 +251,7 @@ export function FastCommentsEmbedCore(
                           }));
                       })();
                     `;
-            webview.injectJavaScript(js);
+            webviewRef.current.injectJavaScript(js);
           }
         }
       }
@@ -235,28 +307,67 @@ export function FastCommentsEmbedCore(
     );
   }, [props.config, widgetId]);
 
-  return (
-    <WebView
-      ref={(ref) => {
-        webview = ref;
-      }}
-      style={{ height, backgroundColor: props.backgroundColor }}
-      startInLoadingState={true}
-      renderLoading={
-        props.renderLoading ?? (() => <ActivityIndicator size="small" />)
+  useEffect(() => {
+    if (props.disableKeyboardAvoidance) {
+      return undefined;
+    }
+    const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
+      keyboardTopYRef.current = e.endCoordinates.screenY;
+      applyKeyboardAvoidance();
+    });
+    const changeSub = Keyboard.addListener('keyboardDidChangeFrame', (e) => {
+      if (keyboardTopYRef.current !== null) {
+        keyboardTopYRef.current = e.endCoordinates.screenY;
+        applyKeyboardAvoidance();
       }
-      renderError={props.renderError}
-      scalesPageToFit={true}
-      source={{ uri }}
-      domStorageEnabled={true}
-      javaScriptEnabled={true}
-      nestedScrollEnabled={true}
-      overScrollMode="never"
-      showsVerticalScrollIndicator={props.showsVerticalScrollIndicator}
-      onMessage={(event) => eventHandler(event)}
-      onShouldStartLoadWithRequest={shouldStartLoadWithRequest}
-      onError={props.onError}
-      onLoad={props.onLoad}
-    />
+    });
+    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
+      clearKeyboardAvoidance();
+    });
+    return () => {
+      showSub.remove();
+      changeSub.remove();
+      hideSub.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.disableKeyboardAvoidance]);
+
+  const effectiveHeight = cappedHeight !== null ? cappedHeight : autoHeight;
+  const injectedJavaScript = props.disableKeyboardAvoidance
+    ? undefined
+    : buildKeyboardAvoidanceScript(instanceIdRef.current);
+
+  return (
+    <View
+      ref={containerRef}
+      // collapsable={false} keeps this View in the native hierarchy on Android
+      // so measureInWindow works when positioning above the keyboard.
+      collapsable={false}
+      style={{ backgroundColor: props.backgroundColor }}
+    >
+      <WebView
+        ref={(ref) => {
+          webviewRef.current = ref;
+        }}
+        style={{ height: effectiveHeight, backgroundColor: props.backgroundColor }}
+        startInLoadingState={true}
+        renderLoading={
+          props.renderLoading ?? (() => <ActivityIndicator size="small" />)
+        }
+        renderError={props.renderError}
+        scalesPageToFit={true}
+        source={{ uri }}
+        injectedJavaScript={injectedJavaScript}
+        domStorageEnabled={true}
+        javaScriptEnabled={true}
+        nestedScrollEnabled={true}
+        overScrollMode="never"
+        showsVerticalScrollIndicator={props.showsVerticalScrollIndicator}
+        onMessage={(event) => eventHandler(event)}
+        onShouldStartLoadWithRequest={shouldStartLoadWithRequest}
+        onError={props.onError}
+        onLoad={props.onLoad}
+      />
+    </View>
   );
 }

--- a/src/keyboard-avoidance.ts
+++ b/src/keyboard-avoidance.ts
@@ -1,0 +1,89 @@
+export interface KeyboardAvoidHeightParams {
+  /** The full content height the embedded page has reported via update-height. */
+  autoHeight: number;
+  /** The widget container's top edge, in window coordinates (from measureInWindow). */
+  containerTopY: number;
+  /** The top edge of the keyboard, in the same coordinate space as containerTopY. */
+  keyboardTopY: number;
+  /** Smallest height we'll ever shrink the WebView to, so it never disappears. */
+  minHeight?: number;
+}
+
+/**
+ * Works out the height the comment WebView should render at while a field is
+ * focused and the keyboard is up.
+ *
+ * The widget renders the whole comment UI (list + input) inside a single
+ * WebView whose height normally tracks its full content height, so the page is
+ * never internally scrollable and the keyboard simply overlays the bottom of
+ * it. To give the focused field room to move above the keyboard we temporarily
+ * shrink the WebView so its bottom edge sits at the top of the keyboard; the
+ * now-overflowing page can then scroll the field into view.
+ *
+ * Returns `autoHeight` unchanged when the widget already fits entirely above
+ * the keyboard (no capping needed).
+ */
+export function computeKeyboardAvoidHeight({
+  autoHeight,
+  containerTopY,
+  keyboardTopY,
+  minHeight = 120,
+}: KeyboardAvoidHeightParams): number {
+  const available = keyboardTopY - containerTopY;
+  if (available >= autoHeight) {
+    return autoHeight;
+  }
+  return Math.max(minHeight, available);
+}
+
+/**
+ * Builds the script injected into the WebView to bridge keyboard handling.
+ *
+ * It reports when a text field inside the page gains/loses focus (so the native
+ * side knows when to apply the height cap above) and exposes
+ * `window.__fcScrollFocusedIntoView()` so the native side can pull the focused
+ * field into the visible band once the WebView has been resized.
+ */
+export function buildKeyboardAvoidanceScript(instanceId: string): string {
+  const id = JSON.stringify(instanceId);
+  return `
+(function () {
+  if (window.__fcKbAvoidInstalled) { return; }
+  window.__fcKbAvoidInstalled = true;
+  var instanceId = ${id};
+  function isTextField(el) {
+    if (!el) { return false; }
+    var tag = (el.tagName || '').toLowerCase();
+    if (tag === 'textarea') { return true; }
+    if (el.isContentEditable) { return true; }
+    if (tag === 'input') {
+      var type = (el.getAttribute('type') || 'text').toLowerCase();
+      return ['text', 'search', 'email', 'url', 'tel', 'password', 'number', ''].indexOf(type) !== -1;
+    }
+    return false;
+  }
+  function post(type) {
+    try {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: type, instanceId: instanceId }));
+    } catch (e) {}
+  }
+  document.addEventListener('focusin', function (e) {
+    if (isTextField(e.target)) { post('fc-input-focus'); }
+  }, true);
+  document.addEventListener('focusout', function (e) {
+    if (isTextField(e.target)) { post('fc-input-blur'); }
+  }, true);
+  window.__fcScrollFocusedIntoView = function () {
+    var el = document.activeElement;
+    if (el && typeof el.scrollIntoView === 'function') {
+      try {
+        el.scrollIntoView({ block: 'center', inline: 'nearest' });
+      } catch (e) {
+        el.scrollIntoView();
+      }
+    }
+  };
+})();
+true;
+`;
+}


### PR DESCRIPTION
## Problem

On phones, focusing the comment field doesn't move it above the keyboard. A field lower on the screen ends up completely hidden behind the keyboard.

### Root cause

The comment UI (list **and** input) renders inside a single `WebView` whose height is pinned to its full content height (`embed-core.tsx` `update-height` handling). Because the WebView is exactly as tall as its content:

- the embedded page is never internally scrollable (page height == WebView height), and
- the WebView's viewport never shrinks when the keyboard opens (its height is fixed by RN; the keyboard just overlays it).

So none of the usual keyboard-avoidance paths have room to work: the browser's native "scroll focused input above keyboard" can't engage, `scrollIntoView` has nowhere to scroll, and the host app's `ScrollView` doesn't auto-scroll because the focus happens *inside* the WebView where RN can't see it. `adjustResize` is already set on Android but can't help an auto-height WebView.

## Fix

While a text field inside the WebView is focused and the keyboard is up, temporarily shrink the WebView so its bottom edge sits at the top of the keyboard, then scroll the focused field into the now-visible band. Restore auto-height on keyboard hide.

- **`src/keyboard-avoidance.ts`** (new): pure, unit-tested `computeKeyboardAvoidHeight(...)` (the height math) and `buildKeyboardAvoidanceScript(...)` (injected JS that posts `fc-input-focus`/`fc-input-blur` on `focusin`/`focusout` of inputs/textareas/contenteditables, and exposes `window.__fcScrollFocusedIntoView()`).
- **`src/embed-core.tsx`**: adds `Keyboard` listeners (`keyboardDidShow`/`Hide`/`ChangeFrame`), tracks focus + keyboard-top, measures the widget's on-screen position via a `collapsable={false}` wrapper `View`, caps the WebView height accordingly, and injects the scroll call. Splits `height` into `autoHeight` (content) and `cappedHeight` (keyboard mode).

### Behavior / API

- **On by default.** Pass `disableKeyboardAvoidance` to `FastCommentsCommentWidget` / `FastCommentsLiveChatWidget` to turn it off.

## Testing

- `yarn jest` (new `src/__tests__/keyboard-avoidance.test.ts`, 6 red-green cases for the height math), `yarn typescript`, and `tsc -p tsconfig.build.json` all pass.
- `yarn lint` fails pre-existing and project-wide (parser rejects `import`/`export` in every file, including untouched ones) - not introduced here.
- Runtime keyboard behavior still needs a device/emulator run on iOS and Android. On Android, `measureInWindow` (window coords) vs the keyboard's `screenY` (screen coords) can differ by the status-bar height; the field is scrolled to the center of the band to absorb that, which is the knob to tune if it looks slightly off.