### PR TITLE
Add nestedScrollEnabled prop, default to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/jest": "^26.0.0",
     "@types/react": "^17.0.37",
     "@types/react-native": "0.68.20",
+    "@types/react-test-renderer": "17.0.2",
     "commitlint": "^11.0.0",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^7.0.0",
@@ -65,9 +66,10 @@
     "react": "17.0.2",
     "react-native": "0.68.7",
     "react-native-builder-bob": "^0.18.2",
+    "react-native-webview": "13.6.4",
+    "react-test-renderer": "17.0.2",
     "release-it": "^14.2.2",
-    "typescript": "^5.7.3",
-    "react-native-webview": "13.6.4"
+    "typescript": "^5.7.3"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -1,1 +1,39 @@
-it.todo('write a test');
+import React from 'react';
+import { act, create, ReactTestRenderer } from 'react-test-renderer';
+import { FastCommentsCommentWidget } from '../index';
+
+jest.mock('react-native-webview', () => {
+  const ReactLib = require('react');
+  return {
+    __esModule: true,
+    default: ReactLib.forwardRef(() => null),
+  };
+});
+
+const WebView = require('react-native-webview').default;
+
+function render(element: React.ReactElement): ReactTestRenderer {
+  let renderer: ReactTestRenderer | undefined;
+  act(() => {
+    renderer = create(element);
+  });
+  return renderer!;
+}
+
+describe('FastCommentsEmbedCore scroll behavior', () => {
+  const config = { tenantId: 'demo', urlId: 'test' };
+
+  it('defaults nestedScrollEnabled to false so parent scroll views keep the gesture', () => {
+    const renderer = render(<FastCommentsCommentWidget config={config} />);
+    const webview = renderer.root.findByType(WebView);
+    expect(webview.props.nestedScrollEnabled).toBe(false);
+  });
+
+  it('passes nestedScrollEnabled through when explicitly enabled', () => {
+    const renderer = render(
+      <FastCommentsCommentWidget config={config} nestedScrollEnabled={true} />
+    );
+    const webview = renderer.root.findByType(WebView);
+    expect(webview.props.nestedScrollEnabled).toBe(true);
+  });
+});

--- a/src/embed-core.tsx
+++ b/src/embed-core.tsx
@@ -19,6 +19,14 @@ export interface FastCommentsWidgetParameters {
   onError?: (error: WebViewErrorEvent) => void;
   openURL?: (url: string) => boolean;
   showsVerticalScrollIndicator?: boolean;
+  /**
+   * On Android, when true the widget claims vertical drag gestures for its
+   * internal scrolling, which prevents a parent ScrollView/FlatList from
+   * scrolling. Leave false (the default) for auto-height widgets embedded in
+   * a scrollable screen; only enable for fixed-height widgets that need to
+   * scroll internally.
+   */
+  nestedScrollEnabled?: boolean;
   renderLoading?: () => ReactElement;
   renderError?: (
     errorDomain: string | undefined,
@@ -246,7 +254,7 @@ export function FastCommentsEmbedCore(
       source={{ uri }}
       domStorageEnabled={true}
       javaScriptEnabled={true}
-      nestedScrollEnabled={true}
+      nestedScrollEnabled={props.nestedScrollEnabled ?? false}
       overScrollMode="never"
       showsVerticalScrollIndicator={props.showsVerticalScrollIndicator}
       onMessage={(event) => eventHandler(event)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,13 @@
   dependencies:
     "@types/react" "^17"
 
+"@types/react-test-renderer@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.2.tgz#5f800a39b12ac8d2a2149e7e1885215bcf4edbbf"
+  integrity sha512-+F1KONQTBHDBBhbHuT2GNydeMpPuviduXIVJRB7Y4nma4NR5DrTJfMMZ+jbhEHbpwL+Uqhs1WXh4KHiyrtYTPg==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react@^17", "@types/react@^17.0.37":
   version "17.0.37"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz"
@@ -7516,10 +7523,15 @@ react-devtools-core@^4.23.0:
     shell-quote "^1.6.1"
     ws "^7"
 
-"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1:
+"react-is@^16.12.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-is@^16.8.1:
   version "16.13.1"
@@ -7626,6 +7638,24 @@ react-shallow-renderer@16.14.1:
   dependencies:
     object-assign "^4.1.1"
     react-is "^16.12.0 || ^17.0.0"
+
+react-shallow-renderer@^16.13.1:
+  version "16.15.0"
+  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^16.12.0 || ^17.0.0 || ^18.0.0"
+
+react-test-renderer@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
+  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+  dependencies:
+    object-assign "^4.1.1"
+    react-is "^17.0.2"
+    react-shallow-renderer "^16.13.1"
+    scheduler "^0.20.2"
 
 react@17.0.2:
   version "17.0.2"


### PR DESCRIPTION
## Summary

- The WebView hardcoded `nestedScrollEnabled={true}`, which on Android makes RNCWebView call `requestDisallowInterceptTouchEvent(true)` on every touch, claiming the gesture for the whole drag. Widgets embedded in a parent ScrollView/FlatList (e.g. comments under each post in a feed) trapped the user's scroll even when auto-height left only a 1-2px internal overflow.
- Adds a `nestedScrollEnabled` prop to `FastCommentsWidgetParameters`, defaulting to **false** so parent scroll views keep the gesture.
- Fixed-height embeds that need internal scrolling (e.g. live chat in a scrollable screen) can opt back in with `nestedScrollEnabled={true}`. Note Android WebView never hands the gesture back to the parent at the scroll boundary; that is an upstream limitation, not configurable here.

## Behavior change

Anyone relying on the old always-on behavior must now pass `nestedScrollEnabled={true}`.

## Testing

- Added red-green tests with react-test-renderer covering the default and explicit opt-in (new dev deps: react-test-renderer, @types/react-test-renderer).
- `npx jest` passes, `tsc --noEmit` clean.