### PR TITLE
docs: clarify WebView/iframe wrapper, recommend the native SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FastComments React Native Wrapper
 
+> **Heads up:** this library renders the FastComments web widget inside a WebView (an iframe on web). It is the quickest way to get every FastComments feature, and it inherits web fixes automatically. For the best experience we recommend [**fastcomments-react-native-sdk**](https://github.com/FastComments/fastcomments-react-native-sdk), a fully native implementation: real React Native components instead of a WebView, full theming via design tokens, a live chat widget, and web support. Use this wrapper if you specifically want the WebView-based widget; otherwise prefer the native SDK.
+
 ## Live Showcase
 
 To see every widget and flow running locally against the public `demo` tenant, clone the repo and run:


### PR DESCRIPTION
Adds a prominent note at the top of the README explaining that this library renders the FastComments web widget in a WebView (iframe on web), and that for the best experience we recommend the fully native [fastcomments-react-native-sdk](https://github.com/FastComments/fastcomments-react-native-sdk).

The repo already had a 'Consider The Native SDK' section lower down; this surfaces the guidance up top where new users will see it first.